### PR TITLE
Download ble-serial-server from github

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,8 +34,9 @@ apps:
     plugs: [raw-usb]
 parts:
   qt:
-    source: "./externals/ble-serial-server/src"
-    source-type: "local"
+    source: "https://github.com/roshub/ble-serial-server.git"
+    source-type: "git"
+    source-commit: "ccd1cd95d381de7d135ebd30ef9b83df848eaba0"
     plugin: qmake
     project-files:
       - bleSerialServer.pro


### PR DESCRIPTION
```
Pulling nmcli 
[01/Sep/2019:22:24:52 +0000] "GET http://ftpmaster.internal/ubuntu/dists/bionic/InRelease HTTP/1.1" 304 - "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:24:52 +0000] "GET http://ftpmaster.internal/ubuntu/dists/bionic-security/InRelease HTTP/1.1" 304 - "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:24:52 +0000] "GET http://ftpmaster.internal/ubuntu/dists/bionic-updates/InRelease HTTP/1.1" 304 - "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:24:58 +0000] "GET http://ftpmaster.internal/ubuntu/pool/universe/q/qtconnectivity-opensource-src/libqt5bluetooth5-bin_5.9.5-0ubuntu1_arm64.deb HTTP/1.1" 200 10636 "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:25:01 +0000] "GET http://ftpmaster.internal/ubuntu/pool/main/i/icu/libicu60_60.2-3ubuntu3_arm64.deb HTTP/1.1" 200 7984896 "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:25:01 +0000] "GET http://ftpmaster.internal/ubuntu/pool/main/q/qtbase-opensource-src/libqt5dbus5_5.9.5%2bdfsg-0ubuntu2.1_arm64.deb HTTP/1.1" 200 166432 "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:25:02 +0000] "GET http://ftpmaster.internal/ubuntu/pool/main/q/qtbase-opensource-src/libqt5core5a_5.9.5%2bdfsg-0ubuntu2.1_arm64.deb HTTP/1.1" 200 1933452 "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:25:02 +0000] "GET http://ftpmaster.internal/ubuntu/pool/universe/q/qtconnectivity-opensource-src/libqt5bluetooth5_5.9.5-0ubuntu1_arm64.deb HTTP/1.1" 200 233376 "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:25:03 +0000] "GET http://ftpmaster.internal/ubuntu/pool/main/q/qtbase-opensource-src/libqt5network5_5.9.5%2bdfsg-0ubuntu2.1_arm64.deb HTTP/1.1" 200 534232 "-" "Debian APT-HTTP/1.3 (1.2.32)"
[01/Sep/2019:22:25:03 +0000] "GET http://ftpmaster.internal/ubuntu/pool/main/d/double-conversion/libdouble-conversion1_2.0.1-4ubuntu1_arm64.deb HTTP/1.1" 200 29646 "-" "Debian APT-HTTP/1.3 (1.2.32)"

Hit http://ftpmaster.internal/ubuntu bionic InRelease

Hit http://ftpmaster.internal/ubuntu bionic-security InRelease

Hit http://ftpmaster.internal/ubuntu bionic-updates InRelease

Fetched 0 B in 0s (0 B/s)

Get:1 libqt5bluetooth5-bin_5.9.5-0ubuntu1_arm64.deb [10.6 kB]

Fetched 10.6 kB in 0s (0 B/s)

Get:1 libicu60_60.2-3ubuntu3_arm64.deb [7985 kB]

Fetched 7985 kB in 0s (0 B/s)

Get:1 libqt5dbus5_5.9.5+dfsg-0ubuntu2.1_arm64.deb [166 kB]

Fetched 166 kB in 0s (0 B/s)

Get:1 libqt5core5a_5.9.5+dfsg-0ubuntu2.1_arm64.deb [1933 kB]

Fetched 1933 kB in 0s (0 B/s)

Get:1 libqt5bluetooth5_5.9.5-0ubuntu1_arm64.deb [233 kB]

Fetched 233 kB in 0s (0 B/s)

Get:1 libqt5network5_5.9.5+dfsg-0ubuntu2.1_arm64.deb [534 kB]

Fetched 534 kB in 0s (0 B/s)

Get:1 libdouble-conversion1_2.0.1-4ubuntu1_arm64.deb [29.6 kB]

Fetched 29.6 kB in 0s (0 B/s)
Pulling qt 
'/build/roshubd/externals/ble-serial-server/src' is not a directory
Build failed
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/lpbuildd/target/build_snap.py", line 267, in run
    self.pull()
  File "/usr/lib/python2.7/dist-packages/lpbuildd/target/build_snap.py", line 233, in pull
    env=env)
  File "/usr/lib/python2.7/dist-packages/lpbuildd/target/build_snap.py", line 104, in run_build_command
    return self.backend.run(args, env=full_env, **kwargs)
  File "/usr/lib/python2.7/dist-packages/lpbuildd/target/lxd.py", line 502, in run
    subprocess.check_call(cmd, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['lxc', 'exec', 'lp-bionic-arm64', '--env', 'LANG=C.UTF-8', '--env', 'SHELL=/bin/sh', '--env', 'SNAPCRAFT_LOCAL_SOURCES=1', '--env', 'SNAPCRAFT_SETUP_CORE=1', '--env', 'SNAPCRAFT_BUILD_INFO=1', '--env', 'SNAPCRAFT_IMAGE_INFO={"build-request-id": "lp-51156664", "build-request-timestamp": "2019-09-01T22:16:22Z", "build_url": "https://launchpad.net/~build.snapcraft.io/+snap/f9a617ae041144f02fc243e514ab5caa/+build/663132"}', '--env', 'SNAPCRAFT_BUILD_ENVIRONMENT=host', '--env', 'http_proxy=http://10.10.10.1:8222/', '--env', 'https_proxy=http://10.10.10.1:8222/', '--env', 'GIT_PROXY_COMMAND=/usr/local/bin/snap-git-proxy', '--', '/bin/sh', '-c', 'cd /build/roshubd && linux64 snapcraft pull']' returned non-zero exit status 2
Revoking proxy token...
RUN: /usr/share/launchpad-buildd/bin/in-target scan-for-processes --backend=lxd --series=bionic --arch=arm64 SNAPBUILD-663132
Scanning for processes to kill in build SNAPBUILD-663132
```